### PR TITLE
Adding Gatsby Plugin keywords in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   },
   "author": "Coding Defined <codingdefined@gmail.com> (http://www.codingdefined.com)",
   "license": "MIT",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin"
+  ],
   "dependencies": {
     "utopian-api": "^0.4.1"
   },


### PR DESCRIPTION
Hello 👋

As part of https://github.com/gatsbyjs/gatsby/issues/14013, I would like to add `gatsby` and `gatsby-plugin` keywords to the package.json file of your plugin.

It is documented in https://www.gatsbyjs.org/contributing/submit-to-plugin-library/ if you would like to know more about it.

If you accept to merge this PR, could you also publish a patch version of your plugin on NPM? Let me know if I can assist in any way with this. 🙂

Thank you very much!